### PR TITLE
ci: provide database url for Prisma build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     name: app-checks
     runs-on: ubuntu-latest
 
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
     defaults:
       run:
         working-directory: app
@@ -29,12 +32,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: app/package-lock.json
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
 
       - name: Run lint
         run: npm run lint


### PR DESCRIPTION
# Pull Request: Fix Build and CI Type Errors

## Summary

This PR fixes TypeScript build errors that appeared during `npm run build` and GitHub Actions CI.

The main issue was that several routes relied on weak or missing Prisma-generated type inference. Because of strict TypeScript settings, callback parameters inside `.map()`, `.find()`, `.filter()`, and `.reduce()` became implicitly typed as `any`.

This PR also updates CI so Prisma has access to `DATABASE_URL` during build.

## Changes Made

### TypeScript Build Fixes

Updated affected API routes to use existing shared project types from:

```text
app/src/lib/types